### PR TITLE
Add message about VAT

### DIFF
--- a/Pages/sthlm-2024/Index.cshtml
+++ b/Pages/sthlm-2024/Index.cshtml
@@ -679,6 +679,12 @@
                         Do you wish to buy more than five tickets and/or prefer an invoice?
                         Use the form above and select the option <strong>pay using invoice (more than 5 tickets)</strong> when completing your order.
                         For 5 tickets or less we charge an extra fee of 100kr for invoices.
+                        
+                        <h3>VAT and Swetugg</h3>
+                        Swetugg is a registered Swedish non-profit organization. We work to spread knowledge in the community and not for profits.
+                        Because of this, we do not charge VAT on any transactions; neither invoices, nor card.
+                        The price you see on the website is without VAT, and no VAT will be added.
+                        Feel free to contact us if you have any other questions regarding this.
                     </p>
                 }
                 else


### PR DESCRIPTION
Hello friends 😊

As the treasurer, I've now gotten a few questions about VAT regarding Swetugg. I noticed there wasn't any information on the website about this so I created this small PR that adds that information.

I simply edited the file and added the info. I have not been able to run and test the changes because I don't have the database or anything else setup on my machie.

Question:
- Should I have added a "feature flag" for enabling/disabling the info? (as I see with `earlyBirdAvailable`)
- If I do this again later, who should I add as reviewer? Should I add any reviewers at all?