### PR TITLE
[PROPOSAL] Publish tickets for 2025

### DIFF
--- a/Pages/sthlm-2025/Index.cshtml
+++ b/Pages/sthlm-2025/Index.cshtml
@@ -47,7 +47,7 @@
         ("speakers", true),
         ("sessions", false),
         ("schedule", false),
-        ("tickets", false),
+        ("tickets", true),
         ("contact", true),
         ("members", false)
     }

--- a/Pages/sthlm-2025/Index.cshtml
+++ b/Pages/sthlm-2025/Index.cshtml
@@ -593,8 +593,8 @@
                 {
                     <!-- Ticket Tailor Widget. Paste this into your website where you want the widget to appear. Do not change the code or the widget may not work properly. -->
                     <div class="tt-widget">
-                            <div class="tt-widget-fallback"><p><a href="https://www.tickettailor.com/checkout/new-session/id/4268885/chk/97eb/" target="_blank">Click here to buy tickets</a><br /></p></div>
-                            <script src="https://cdn.tickettailor.com/js/widgets/min/widget.js" data-url="https://www.tickettailor.com/checkout/new-session/id/4268885/chk/97eb/" data-type="inline" data-inline-minimal="true" data-inline-show-logo="false" data-inline-bg-fill="false" data-inline-inherit-ref-from-url-param="" data-inline-ref=""></script>
+                            <div class="tt-widget-fallback"><p><a href="https://www.tickettailor.com/checkout/new-session/id/4751923/chk/fcde/?ref=swetugg-site" target="_blank">Click here to buy tickets</a><br /></p></div>
+                            <script src="https://cdn.tickettailor.com/js/widgets/min/widget.js" data-url="https://www.tickettailor.com/checkout/new-session/id/4751923/chk/fcde/?ref=swetugg-site" data-type="inline" data-inline-minimal="true" data-inline-show-logo="false" data-inline-bg-fill="true" data-inline-inherit-ref-from-url-param="" data-inline-ref="swetugg-site"></script>
                     </div>
                     <!-- End of Ticket Tailor Widget -->
                    <p>
@@ -602,7 +602,7 @@
                         {
                             <h3>Early Bird?</h3>
                             <p>
-                            The first batch of tickets that we sell will have a discount and they are called "early bird", but they are limited in number.
+                                The first batch of tickets that we sell will have a discount and they are called "early bird", but they are limited in number.
                                 When they are out, they are out! So be quick! (if the are not listed, they are out)
                             </p>
                         }
@@ -610,7 +610,7 @@
                         <p>
                             Do you wish to buy more than five tickets and/or prefer an invoice?
                             Use the form above and select the option <strong>pay using invoice (more than 5 tickets)</strong> when completing your order.
-                            For 5 tickets or less we charge an extra fee of 200kr for invoices.
+                            For less than 5 tickets we charge an extra fee of 200kr for invoices.
                         </p>
                         
                         <h3>VAT and Swetugg</h3>
@@ -625,7 +625,7 @@
                 else
                 {
                     <p>
-                        You can can start buying tickets on Monday 10th of June at 10:00! Don't missout on the early bird offer.
+                        You can can start buying tickets on Thursday 24th of October at 10:00! Don't missout on the early bird offer.
                     </p>
                     @*<p>
                 Tickets for Swetugg 2023 have sold out. If we are able to open sales again, we will announce it on <a href="https://twitter.com/swetugg">Twitter</a> and <a href="https://facebook.com/swetugg">Facebook</a>, so make sure to follow us there!

--- a/Pages/sthlm-2025/Index.cshtml
+++ b/Pages/sthlm-2025/Index.cshtml
@@ -23,7 +23,7 @@
     }
 
     bool isCfpOpen = false; //New logic will be added on issue #178
-    bool earlyBirdAvailable = false;
+    bool earlyBirdAvailable = true;
 
     int speakersLeft = conference.MinNumberOfSpeakers - conference.Speakers.Count;
 


### PR DESCRIPTION
This is a **draft** PR that could potentially be used to enable sales of tickets for Stockholm 2025.
I created it as a way to hopefully provide you with enough information needed to get the tickets available on the website. Feel free to take the IDs from this PR and make another PR ^^

## Things done

* Update the TicketTailor embed
* Activate the ticket section and the early bird text
* Change text to show that tickets will go live on Thursday at 10

## Questions / uncertainties

- [ ] I have no clue how to change the configuration (when tickets should be able to be purchased)
- [ ] Not sure if the mailchimp form is working. I've verified that the IDs are correct, but not sure if the actual form will work (the mailchimp website gives different stuff)
